### PR TITLE
Don't register raven if no DSN configured

### DIFF
--- a/src/RavenServiceProvider.php
+++ b/src/RavenServiceProvider.php
@@ -1,7 +1,6 @@
 <?php namespace Jenssegers\Raven;
 
 use Illuminate\Support\ServiceProvider;
-use InvalidArgumentException;
 use Raven_Client;
 use Raven_ErrorHandler;
 
@@ -41,7 +40,7 @@ class RavenServiceProvider extends ServiceProvider {
         $dsn = getenv('RAVEN_DSN') ?: $app['config']->get('services.raven.dsn');
 
         if (!$dsn) {
-            return null;
+            return;
         }
 
         $this->app['Raven_Client'] = $this->app->share(function ($app) use ($dsn)

--- a/src/RavenServiceProvider.php
+++ b/src/RavenServiceProvider.php
@@ -38,22 +38,19 @@ class RavenServiceProvider extends ServiceProvider {
     public function register()
     {
         $app = $this->app;
+        $dsn = getenv('RAVEN_DSN') ?: $app['config']->get('services.raven.dsn');
 
-        $this->app['Raven_Client'] = $this->app->share(function ($app)
+        if (!$dsn) {
+            return null;
+        }
+
+        $this->app['Raven_Client'] = $this->app->share(function ($app) use ($dsn)
         {
             $defaults = [
                 'curl_method' => 'async',
             ];
 
             $config = array_merge($defaults, $app['config']->get('services.raven', []));
-
-            $dsn = getenv('RAVEN_DSN') ?: $app['config']->get('services.raven.dsn');
-
-            if (! $dsn)
-            {
-                throw new InvalidArgumentException('Raven DSN not configured');
-            }
-
             return new Raven_Client($dsn, array_except($config, ['dsn']));
         });
 


### PR DESCRIPTION
If a Raven DSN hasn't been configured, then it just won't register rather than throwing an exception.