### PR TITLE
update composer.json to newer sentry version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "illuminate/support": "^4.0|^5.0",
-        "sentry/sentry": "~0.11"
+        "sentry/sentry": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.0",


### PR DESCRIPTION
This removes the warning "This event was reported with an old version of the php SDK." from sentry dashboard.